### PR TITLE
fix: assets source become undefined in some scenario

### DIFF
--- a/src/HtmlInlineScriptPlugin.ts
+++ b/src/HtmlInlineScriptPlugin.ts
@@ -64,14 +64,13 @@ class HtmlInlineScriptPlugin {
         );
         return data;
       });
+    });
 
-      hooks.beforeEmit.tap(`${PLUGIN_PREFIX}_beforeEmit`, (data) => {
-        Object.keys(compilation.assets).forEach((assetName) => {
-          if (this.isFileNeedsToBeInlined(assetName)) {
-            delete compilation.assets[assetName];
-          }
-        });
-        return data;
+    compiler.hooks.emit.tap(`${PLUGIN_PREFIX}_emit`, (compilation) => {
+      Object.keys(compilation.assets).forEach((assetName) => {
+        if (this.isFileNeedsToBeInlined(assetName)) {
+          delete compilation.assets[assetName];
+        }
       });
     });
   }


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Related to issue #1, where it demonstrate the use of multiple html-webpack-plugin instances in a single webpack compiler.

In that scenario, the script assets was deleted early in the first `beforeEmit` hook, causing the build to throw:
```
ERROR in   TypeError: Cannot read property 'source' of undefined
  
  - HtmlInlineScriptPlugin.js:52 HtmlInlineScriptPlugin.processScriptTag
    [project-name]/[html-inline-script-webpack-plugin]/dist/HtmlInlineScriptPlugin.js:52:34
  
  - HtmlInlineScriptPlugin.js:67 
    [project-name]/[html-inline-script-webpack-plugin]/dist/HtmlInlineScriptPlugin.js:67:103
  
  - Array.map
  
  - HtmlInlineScriptPlugin.js:67 
    [project-name]/[html-inline-script-webpack-plugin]/dist/HtmlInlineScriptPlugin.js:67:69
  
  
  - new Promise
  
  
  - index.js:190 
    [project-name]/[html-webpack-plugin]/index.js:190:87
```


## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
Have setup a minimal webpack which uses html-webpack-plugin instances in a single webpack compiler. Test the build is successful.

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
