### PR TITLE
chore(dev-dependencies): lock version of @types/webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@types/html-webpack-plugin": "^3.2.3",
+    "@types/webpack": "^4.41.26",
     "@types/webpack-sources": "^1.4.0",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,6 +275,18 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
+"@types/webpack@^4.41.26":
+  version "4.41.26"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.26.tgz#27a30d7d531e16489f9c7607c747be6bc1a459ef"
+  integrity sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    source-map "^0.6.0"
+
 "@typescript-eslint/eslint-plugin@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.6.0.tgz#ba2b6cae478b8fca3f2e58ff1313e4198eea2d8a"


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Resolve error of `Argument of type 'import("/html-inline-script-webpack-plugin/node_modules/@types/webpack/index").compilation.Compilation' is not assignable to parameter of type 'import("/html-inline-script-webpack-plugin/node_modules/html-webpack-plugin/node_modules/@types/webpack/index").compilation.Compilation'.` by defining the @types/webpack version in package.json.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
Check if there is no TypeScript error

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [x] Other(s): `chore`

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
