### PR TITLE
fix: fix no construct signatures error throw by typescript

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,15 @@ import HtmlInlineScriptPlugin from './HtmlInlineScriptPlugin';
 
 const isHtmlWebpackPluginV4 = 'getHooks' in htmlWebpackPlugin;
 
-module.exports = isHtmlWebpackPluginV4
-  ? HtmlInlineScriptPlugin
-  : null;
+if (!isHtmlWebpackPluginV4) {
+  // eslint-disable-next-line no-console
+  console.error(
+    '\x1b[35m%s \x1b[31m%s\x1b[0m',
+    '[html-inline-script-webpack-plugin]',
+    'Please upgrade your webpack to version 4 to use this plugin.'
+  );
+
+  throw new Error('VERSION_INCOMPATIBLE');
+}
+
+export = HtmlInlineScriptPlugin;


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Fix error throw by Typescript:
```
This expression is not constructable.
  Type 'typeof import("html-inline-script-webpack-plugin/dist/index")' has no construct signatures.
```

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
Test with real webpack configuration to make sure type can be imported

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
