### PR TITLE
fix: chage the default test scope to avoid targeting map files or gzip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin(),
     new HtmlInlineScriptPlugin([
-      /runtime~.+[.]js/,
-      /app~.+[.]js/
+      /runtime~.+[.]js$/,
+      /app~.+[.]js$/
     ]),
   ]
 }

--- a/src/HtmlInlineScriptPlugin.ts
+++ b/src/HtmlInlineScriptPlugin.ts
@@ -8,7 +8,7 @@ class HtmlInlineScriptPlugin implements WebpackPluginInstance {
   tests: RegExp[];
 
   constructor(tests?: RegExp[]) {
-    this.tests = tests || [/.+[.]js/];
+    this.tests = tests || [/.+[.]js$/];
   }
 
   isFileNeedsToBeInlined(


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Fix invalid regular expression used as default setting for identifying js files from asset name. Related to #114.

This changes applies to v2 of the plugin.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
Tested with:
1. `devtool: 'source-map'` enabled, which generates a `[name].js.map` file
2. `mode: 'development'` enabled, which generates a `[name].js.LICENSE.txt` file

Check to see if the non-js files are correctly emitted.

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
