### PR TITLE
fix: chage the default test scope to avoid targeting map files or gzip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin(),
     new HtmlInlineScriptPlugin([
-      /runtime~.+[.]js/,
-      /app~.+[.]js/
+      /runtime~.+[.]js$/,
+      /app~.+[.]js$/
     ]),
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@commitlint/config-conventional": "^12.0.0",
     "@types/html-webpack-plugin": "^3.2.3",
     "@types/jest": "^26.0.20",
-    "@types/webpack": "^4.41.26",
     "@types/webpack-sources": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^4.15.2",
@@ -54,6 +53,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
+    "@types/webpack": "^4.41.28",
     "html-webpack-plugin": "^4.0.0",
     "webpack": "^4.0.0"
   }

--- a/src/HtmlInlineScriptPlugin.ts
+++ b/src/HtmlInlineScriptPlugin.ts
@@ -8,7 +8,7 @@ class HtmlInlineScriptPlugin implements Plugin {
   tests: RegExp[];
 
   constructor(tests?: RegExp[]) {
-    this.tests = tests || [/.+[.]js/];
+    this.tests = tests || [/.+[.]js$/];
   }
 
   isFileNeedsToBeInlined(

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,7 +850,7 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@^4", "@types/webpack@^4.41.26":
+"@types/webpack@^4":
   version "4.41.27"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.27.tgz#f47da488c8037e7f1b2dbf2714fbbacb61ec0ffc"
   integrity sha512-wK/oi5gcHi72VMTbOaQ70VcDxSQ1uX8S2tukBK9ARuGXrYM/+u4ou73roc7trXDNmCxCoerE8zruQqX/wuHszA==


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Fix invalid regular expression used as default setting for identifying js files from asset name. Related to #114.

This changes applies to v1 of the plugin.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
Tested with:
1. `devtool: 'source-map'` enabled, which generates a `[name].js.map` file
2. `mode: 'development'` enabled, which generates a `[name].js.LICENSE.txt` file

Check to see if the non-js files are correctly emitted.

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
