### PR TITLE
chore(dependabot): drop support for v1 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,22 +18,3 @@ updates:
     reviewers:
       - "icelam"
     open-pull-requests-limit: 10
-
-  # checking for v1 branch which contains v1 code of this plugin
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    target-branch: "v1"
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
-      include: "scope"
-    ignore:
-      - dependency-name: "webpack"
-      - dependency-name: "html-webpack-plugin"
-    reviewers:
-      - "icelam"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Remove dependabot update in `v1` branch as part of deprecation process of v1 (webpack 4 supported) version.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
N/A

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [x] Other(s): `chore`

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
