### PR TITLE
docs: document limitation for dynamic import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ module.exports = {
 ## Known limitations
 1. This plugin does not transform Web Worker syntax like `new Worker(new URL('./worker.js', import.meta.url));``. It simply embeds the source code processed by webpack into HTML files, and emits any JavaScript files that is not processed by the plugin.
 2. This plugin is designed to embed script content into HTML files for deployment to environments where only a single file can be uploaded, or where the script file itself is small enough that it doesn't warrant an additional HTTP request. It is not intended for use in development, and may fail if HMR is enabled.
+3. This plugin does not support inlining scripts that are dynamically imported (the `import()` syntax). The reason is explained in [this issue](https://github.com/icelam/html-inline-script-webpack-plugin/issues/494#issuecomment-2016902280).
 
 ## Contributors
 


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Document limitation on inlining scripts that are dynamically imported on README.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
N/A

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [x] Other(s): `docs`<!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
